### PR TITLE
Modifying the Admin check for the MinGw package installater

### DIFF
--- a/Espressif/install-mingw-package.bat
+++ b/Espressif/install-mingw-package.bat
@@ -4,7 +4,7 @@ cls
 echo.
 echo Installing additional packages for MinGW
 echo.
-at > nul
+net session >nul 2>&1
 if not %ERRORLEVEL% EQU 0 (
       echo Error: To install packages need admin rights.
       echo.


### PR DESCRIPTION
Hello,

I was checking out the build process in windows 7 and windows 10.
In windows 7 it worked perfectly, however in Windows 10 the 'AT' command has been obsolete.
So I searched for alternatives. Here is one I could find from stack exchange:
[Stack-Overflow Answer](http://stackoverflow.com/a/11995662)

I have been using ESP8266 Arduino for most of my development. However your native toolchain gives further advanced control. So I thought I could contribute a little to your efforts.

Thanks again for your wonderful toolchain.

Warm Regards,
Boseji
